### PR TITLE
Set up service directories and ML skeleton

### DIFF
--- a/android_app/README.md
+++ b/android_app/README.md
@@ -1,0 +1,1 @@
+# Android App\nThis directory will contain the Android client.

--- a/backend_service/README.md
+++ b/backend_service/README.md
@@ -1,0 +1,1 @@
+# Backend Service\nThis directory will host the backend API service.

--- a/ml_service/README.md
+++ b/ml_service/README.md
@@ -1,0 +1,1 @@
+# ML Service\nThis directory will contain the ML API built with Flask.

--- a/ml_service/app.py
+++ b/ml_service/app.py
@@ -1,0 +1,10 @@
+from flask import Flask, jsonify
+
+app = Flask(__name__)
+
+@app.route('/health')
+def health():
+    return jsonify({'status': 'ok'})
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)


### PR DESCRIPTION
## Summary
- scaffold ml_service, backend_service, and android_app directories
- add placeholder README files describing each component
- implement a minimal Flask app for the ML service

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fc3fcee38832aa154a755ae6ad8de