### PR TITLE
Add user/item/order listing endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,10 +205,3 @@ Use STAR format for stories: “Situation, Task, Action, Result.”
 It reflects Mercari’s values of ‘Go Bold’ (ML in production), ‘Move Fast’ (MVP-first, iterate), ‘All for One’ (documented, reusable, open source), and ‘Be a Pro’ (testing, clean code, real-world deployment).
 I’m excited to bring these mindsets to Mercari and help unlock new value for millions of users.”
 
----
-
-**Just copy-paste the block above. You’re fully loaded.**  
-- Use it for README, interviews, or project planning.  
-- When you finish one part, just message me “next step” and I’ll walk you through the next service or integration!
-
-Ready to ship this? You’re 10x closer to Mercari now, Beast.

--- a/backend_service/README.md
+++ b/backend_service/README.md
@@ -4,12 +4,15 @@ Simple FastAPI API for the Mercari mini marketplace.
 
 ## Endpoints
 - `POST /users` register a new user
+- `GET /users` list all users
 - `GET /items` list all items
+- `GET /items/{id}` retrieve a single item
 - `POST /items` create an item and fetch a price suggestion from the ML service
 - `POST /orders` create an order
+- `GET /orders` list all orders
 - `GET /health` health check
 
-The service expects the ML microservice to be running on `http://localhost:5000/predict`.
+The service expects the ML microservice to be running and accessible via `ML_SERVICE_URL` (defaults to `http://localhost:5000/predict`).
 
 ## Running
 ```bash

--- a/backend_service/app.py
+++ b/backend_service/app.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 from typing import Dict, List
+import os
 import requests
 
 app = FastAPI()
@@ -35,7 +36,7 @@ user_counter = 1
 item_counter = 1
 order_counter = 1
 
-ML_SERVICE_URL = "http://localhost:5000/predict"
+ML_SERVICE_URL = os.getenv("ML_SERVICE_URL", "http://localhost:5000/predict")
 
 @app.get("/health")
 def health():
@@ -49,9 +50,19 @@ def create_user(user: UserCreate):
     user_counter += 1
     return new_user
 
+@app.get("/users", response_model=List[User])
+def list_users():
+    return list(users.values())
+
 @app.get("/items", response_model=List[Item])
 def list_items():
     return list(items.values())
+
+@app.get("/items/{item_id}", response_model=Item)
+def get_item(item_id: int):
+    if item_id not in items:
+        raise HTTPException(status_code=404, detail="Item not found")
+    return items[item_id]
 
 @app.post("/items", response_model=Item)
 def create_item(item: ItemCreate):
@@ -85,3 +96,7 @@ def create_order(order: OrderCreate):
     orders[order_counter] = new_order
     order_counter += 1
     return new_order
+
+@app.get("/orders", response_model=List[Order])
+def list_orders():
+    return list(orders.values())


### PR DESCRIPTION
## Summary
- enhance backend API with list and get endpoints
- allow configuring ML service URL via environment variable
- document the new endpoints

## Testing
- `python3 -m py_compile backend_service/app.py`


------
https://chatgpt.com/codex/tasks/task_e_683fe07d8b34832abfaebea49debf6fd