### PR TITLE
Align ML service port docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,10 +141,11 @@ def predict():
     return jsonify({'predicted_price': round(float(pred), 2)})
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5001, debug=True)
+    # The ML API listens on port 5000
+    app.run(host='0.0.0.0', port=5000, debug=True)
 
 # Test with:
-curl -X POST http://localhost:5001/predict \
+curl -X POST http://localhost:5000/predict \
 -H "Content-Type: application/json" \
 -d '{"name":"Nike Air Max","item_description":"Good condition, size 9","category_name":"Men/Shoes/Sneakers"}'
 ```

--- a/backend_service/README.md
+++ b/backend_service/README.md
@@ -13,6 +13,11 @@ Simple FastAPI API for the Mercari mini marketplace.
 - `GET /health` health check
 
 The service expects the ML microservice to be running and accessible via `ML_SERVICE_URL` (defaults to `http://localhost:5000/predict`).
+If your ML service runs on a different port, export `ML_SERVICE_URL` before starting:
+
+```bash
+export ML_SERVICE_URL=http://localhost:5001/predict
+```
 
 ## Running
 ```bash


### PR DESCRIPTION
## Summary
- document ML service running on port 5000 in root README
- explain configuring `ML_SERVICE_URL` in backend service README

## Testing
- `python3 -m py_compile ml_service/app.py backend_service/app.py`
- `pip install -r backend_service/requirements.txt`

